### PR TITLE
Update reference to training materials

### DIFF
--- a/_includes/partials/banner.njk
+++ b/_includes/partials/banner.njk
@@ -4,7 +4,6 @@
             <h1><span class="initial">e</span>ditions with <span class="initial">f</span>uture</h1>
             <p class="m-2">rooted in standards, built by the community, meant to last</p>
             <div>
-                <a href="/dh2024" class="btn btn-warning">DH2024</a>
                 <a href="/join" class="btn btn-warning">Join</a>
                 <a href="https://paypal.me/eeditiones" class="btn btn-warning">Donate</a>
             </div>

--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -24,7 +24,7 @@ We collect the materials prepared for different training events in [this Github 
 - Using modelSequence
 - Showing Metadata from the teiHeader
 
-[Workshop Live recording (Video)](https://www.youtube.com/watch?v=QuWrfAS2SWM) [Slides](https://github.com/eeditiones/workshop/blob/master/e-editiones-workshop-20200608.pdf) [Assignments](https://github.com/eeditiones/workshop/blob/master/assignments/A1.md)  
+[Workshop Live recording (Video)](https://www.youtube.com/watch?v=QuWrfAS2SWM) [Slides](https://github.com/eeditiones/workshop/blob/master/slides/e-editiones-workshop-20200608.pdf) [Assignments](https://github.com/eeditiones/workshop/blob/master/assignments/A1.md)  
 [Solutions (Video)](https://www.youtube.com/watch?v=WhcDzCaVzYs&feature=youtu.be)
 
 ### Part 2
@@ -33,7 +33,7 @@ We collect the materials prepared for different training events in [this Github 
 - Output metadata in a separate column
 - Display additional metadata
 
-[Workshop Live recording (Video)](https://www.youtube.com/watch?v=5qu94bhftpk) [Slides](https://github.com/eeditiones/workshop/blob/master/e-editiones-workshop-20200614.pdf)  
+[Workshop Live recording (Video)](https://www.youtube.com/watch?v=5qu94bhftpk) [Slides](https://github.com/eeditiones/workshop/blob/master/slides/e-editiones-workshop-20200614.pdf)  
 [Assignments](https://github.com/eeditiones/workshop/blob/master/assignments/A2.md)  
 [Solutions (Video)](https://www.youtube.com/watch?v=8JUAwjvDCGw)
 
@@ -44,7 +44,7 @@ We collect the materials prepared for different training events in [this Github 
 - Global document styles
 - Download the application to local disk
 
-[Workshop Live recording (Video)](https://www.youtube.com/watch?v=FS36nYFlTbE) [Slides](https://github.com/eeditiones/workshop/blob/master/e-editiones-workshop-20200622.pdf) [Assignements](https://github.com/eeditiones/workshop/blob/master/assignments/A3.md) [Solutions (Video)](https://youtu.be/HxCo303tgOk)
+[Workshop Live recording (Video)](https://www.youtube.com/watch?v=FS36nYFlTbE) [Slides](https://github.com/eeditiones/workshop/blob/master/slides/e-editiones-workshop-20200622.pdf) [Assignements](https://github.com/eeditiones/workshop/blob/master/assignments/A3.md) [Solutions (Video)](https://youtu.be/HxCo303tgOk)
 
 ## Helpful Literature and Websites
 

--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -11,9 +11,9 @@ If you want to dive in straight away go to the [TEI Publisher Documentation](htt
 
 ## TEI Publisher From Scratch
 
-To get started you can work through our workshop «TEI Publisher From Scratch». It is recommended to first view the instructions by Wolfgang Meier. If you have to catch up with some technologies or standards you will find helpful links and literature below.
+We collect the materials prepared for different training events in [this Github repository](https://github.com/eeditiones/workshop/). To get started, you can work through our most comprehensive workshop: «TEI Publisher From Scratch». It is recommended to first view the instructions by Wolfgang Meier. If you have to catch up with some technologies or standards you will find helpful links and literature below.
 
-[GitHub repository of the workshop](https://github.com/eeditiones/workshop/)
+[Workshop instructions](https://github.com/eeditiones/workshop/blob/master/2020-06_tp-from-scratch.md)
 
 ### Part 1
 


### PR DESCRIPTION
This PR also includes another minor change: the deletion of the DH2024 button in the landing page by @windauer’s request.